### PR TITLE
Undefined requests

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -112,6 +112,7 @@ export type LooseRequest =
   | Request
   | ConstructorParameters<typeof Request>
   | ConstructorParameters<typeof Request>[0]
+  | undefined
 export interface RequestCreator<ActionTypes extends AnyAction> {
   (action: ActionTypes): MaybePromise<Request | undefined>
 }

--- a/src/createFetchAction.js
+++ b/src/createFetchAction.js
@@ -37,10 +37,12 @@ export const createFetchAction = ({
     if (responder) {
       response = await responder(request, action)
     }
-    if (responder && !fetch) {
+    if (responder && (!fetch || !request)) {
       invariant(
         response,
-        '@@fetch-actions/createFetchAction responder must always return a valid (non-falsey) response when fetch is undefined'
+        `@@fetch-actions/createFetchAction responder must always return a valid (non-falsey) response when ${
+          fetch ? `request is ${request}` : 'fetch is undefined'
+        }`
       )
     }
     if (!response) {

--- a/test/createFetchAction.spec.js
+++ b/test/createFetchAction.spec.js
@@ -130,7 +130,21 @@ describe('createFetchAction', () => {
     return fetchAction(action)
       .then((response) => realConsole.log(response))
       .catch((e) => {
-        expect(true).toEqual(true)
+        expect(e.message).toContain('fetch is undefined')
+      })
+  })
+
+  it('throws on good responder function when request is missing and responder returns false', () => {
+    const fetchAction = createFetchAction({
+      fetch,
+      requestCreator: () => {},
+      responder,
+    })
+    expect.assertions(1)
+    return fetchAction(action)
+      .then((response) => realConsole.log(fetch.mock.calls[0][0].url))
+      .catch((e) => {
+        expect(e.message).toContain('request is undefined')
       })
   })
 


### PR DESCRIPTION
This PR loosens the types for `handleRequestCreatorActions` to allow the functions to return undefined, for example:

```
someRequestCreators(
  handleRequestCreatorActions({
    [SAVE]: (action) => {
      if (action.meta.isDeleted) {
        return new Request('/api/…', { method: 'DELETE' })
      }
      // Otherwise, we return undefined and continue on to the next request creator
    },
  }),
  // Additional request creators here
)
```

It also modifies `createFetchAction` so that if the `responder` and `requestCreator` both return falsy values, we throw, rather than making a `fetch(undefined)` call (which makes a GET request with `undefined` in the URL).